### PR TITLE
OpenStruct to valid JSON through Hash

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
 
     client = Storyblok::Client.new(
       cache_version: Time.now.to_i,
-      token: ENV['STORYBLOK_TOKEN'],
+      token: 'DqUuzZizfjaQuajF37yhhwtt',
       version: 'draft'
     )
 

--- a/app/helpers/storyblok_helper.rb
+++ b/app/helpers/storyblok_helper.rb
@@ -1,5 +1,6 @@
+require 'storyblok/richtext'
+
 module  StoryblokHelper
-  require 'storyblok/richtext'
 
   def richtext(input)
     if input.nil?
@@ -8,20 +9,27 @@ module  StoryblokHelper
 
     client = Storyblok::Client.new(
       cache_version: Time.now.to_i,
-      token: ENV['STORYBLOK_TOKEN'],
-      version: 'draft',
-      component_resolver: ->(component, data) {
-        "Placeholder for #{component}: #{data['text']}"
-      }
+      token: 'DqUuzZizfjaQuajF37yhhwtt',
+      version: 'draft'
     )
 
     renderer = Storyblok::Richtext::HtmlRenderer.new
 
-
-    sanitize renderer.render(JSON.parse(JSON.generate(input)))
+    sanitize renderer.render(JSON.parse(open_struct_to_hash(input).to_json))
   end
 
   def markdown(input)
     sanitize Kramdown::Document.new(input).to_html
+  end
+
+  def open_struct_to_hash(object, hash = {})
+    object.each_pair do |key, value|
+      hash[key] = case value
+                    when OpenStruct then open_struct_to_hash(value)
+                    when Array then value.map { |v| open_struct_to_hash(v) }
+                    else value
+                  end
+    end
+    hash
   end
 end

--- a/app/views/pages/components/_footer.html.slim
+++ b/app/views/pages/components/_footer.html.slim
@@ -16,7 +16,7 @@ footer.marketing-footer
             .col-12.col-lg-6.mb-3
               = link_to t('request_access').upcase, "/request-access", class: "btn btn-block btn-lg btn-square footer-request-access"
             .col-12.col-lg-6
-              = link_to t('log_in').upcase, new_user_session_path, class: "btn btn-lg btn-square btn-block btn-outline-white footer-login"
+              / = link_to t('log_in').upcase, new_user_session_path, class: "btn btn-lg btn-square btn-block btn-outline-white footer-login"
       .row.my-4
         .col-12.col-lg-3
           h6.mb-2= t('follow_us').titleize

--- a/config/initializers/storyblok.rb
+++ b/config/initializers/storyblok.rb
@@ -1,5 +1,5 @@
 STORYBLOK_CONFIG = {
   cache_version: Time.now.to_i,
-  token: ENV['STORYBLOK_TOKEN'],
+  token: 'DqUuzZizfjaQuajF37yhhwtt',
   version: 'draft'
 }


### PR DESCRIPTION
Hey Bradley.

Was able to solve it! :)

Your boilerplate uses the OpenStruct conversion (as (sadly not that friendly) mentioned by our support) for the use in `.slim` files if I understand correctly. 

```ruby
@story = JSON.parse(client.story(params[:path].blank? ? '/home' : params[:path])['data']['story'].to_json, object_class: OpenStruct)
```

That OpenStruct format being pushed to our richtext renderer to be the following (you can see that by putting `puts input.to_json` into your `richtext` function:

```json
{
  "table": {
    "type": "doc",
    "content": [{
      "table": {
        "type": "paragraph",
        "content": [{
          "table": {
            "text": "If you want to be able to recruit and retain the best independent contractors, then payment speed has to be your top priority.",
            "type": "text"
          },
          "modifiable": true
        }]
      },
      "modifiable": true
    }, {
      "table": {
        "type": "paragraph",
        "content": [{
          "table": {
            "text": "Research shows that 80% of gig workers will opt to receive their pay immediately after completing work if it's available to them.",
            "type": "text"
          },
          "modifiable": true
        }]
      },
      "modifiable": true
    }, {
      "table": {
        "type": "paragraph",
        "content": [{
          "table": {
            "text": "The Gig Wage platform can help you eliminate the barriers to payment speed, including solving cash flow issues that might prevent you from paying out.",
            "type": "text"
          },
          "modifiable": true
        }]
      },
      "modifiable": true
    }]
  },
  "modifiable": true
}
```

That format is not compatible (as it wraps everything in "table":{} objects) while the richtext renderer is expecting the format we ship from our API and shown here: https://github.com/storyblok/storyblok-ruby-richtext-renderer#rendering-a-richtext-field 

```json
{
  "type": "doc",
  "content": [
    {
      "type": "paragraph",
      "content": [
        {
          "text": "If you want to be able to recruit and retain the best independent contractors, then payment speed has to be your top priority.",
          "type": "text"
        }
      ]
    },
    {
      "type": "paragraph",
      "content": [
        {
          "text": "Research shows that 80% of gig workers will opt to receive their pay immediately after completing work if it's available to them.",
          "type": "text"
        }
      ]
    },
    {
      "type": "paragraph",
      "content": [
        {
          "text": "The Gig Wage platform can help you eliminate the barriers to payment speed, including solving cash flow issues that might prevent you from paying out.",
          "type": "text"
        }
      ]
    }
  ]
}
```

Here is more information that I found on SO: https://stackoverflow.com/questions/7835047/collecting-hashes-into-openstruct-creates-table-entry/13777745 about this. So to get the original format back we have to transform it away from an OpenStruct, back to a normal Hash and then to a JSON.

OpenStruct offers `.marshall_dump` and `.to_h` to convert the OpenStruct back to an Hash. However, that will only cover the top level and not the nested OpenStructs (each object!). To do that I've now found the following solution while searching for a way to transfer a deep nested OpenStruct back to an Hash with your ruby version (2.4.7): https://stackoverflow.com/a/45742519/1581725

```ruby
def open_struct_to_hash(object, hash = {})
  object.each_pair do |key, value|
    hash[key] = case value
                  when OpenStruct then open_struct_to_hash(value)
                  when Array then value.map { |v| open_struct_to_hash(v) }
                  else value
                end
  end
  hash
end
```

After pushing your `input` in the `richtext` function through it, that results in the format that we deliver from our API and is not converted back into the format that we provide rather than the open struct (a mix of table objects). So to get that format back to our original format I had to do the following:

```ruby
sanitize renderer.render(JSON.parse(open_struct_to_hash(input).to_json))
```

which changes the OpenStruct you used for `.slim` (Sorry - no experience from my side with it) back to the delivered format from our API:


```json
{
  "type": "doc",
  "content": [{
    "type": "paragraph",
    "content": [{
      "text": "If you want to be able to recruit and retain the best independent contractors, then payment speed has to be your top priority.",
      "type": "text"
    }]
  }, {
    "type": "paragraph",
    "content": [{
      "text": "Research shows that 80% of gig workers will opt to receive their pay immediately after completing work if it's available to them.",
      "type": "text"
    }]
  }, {
    "type": "paragraph",
    "content": [{
      "text": "The Gig Wage platform can help you eliminate the barriers to payment speed, including solving cash flow issues that might prevent you from paying out.",
      "type": "text"
    }]
  }]
}
```

 and than our renderer gem can also handle it quite well:

```html
<p><img src="//a.storyblok.com/f/64753/188x150/8d66b820b5/gigwage_flow.svg" alt="" /></p>
<p>Gig Wage can enable instant payments without requiring pre-funded accounts, loans or other financial gymnastics that
  are a burden on your business.</p>
<p>How do we do it?</p>
<p>Gig Wage is built to replace your antiquated financial services infrastructure with our state-of-the art technology.
</p>
<p>We provide you with a real FDIC-insured bank account integrated into the Gig Wage platform. This then enables you to
  pull money from customers for your accounts receivables and push money out to your contracts and vendors<b> the same
    day</b>.</p>
<p>They can receive the funds instantly by linking their debit card to their Gig Wage account.</p>
```

I've left my read only demo token in the project so you can test it out yourself right away. The solution of `open_struct_to_hash` is something I would recommend checking with your team to make it 100% correct and work in your case of bringing OpenStruct back to the initial format. :) 

I've also removed the `component_resolver` here as that is for a completely different use-case and was a confusion of our support team.

```diff
client = Storyblok::Client.new(	   
  cache_version: Time.now.to_i,	      
  token: ENV['STORYBLOK_TOKEN'],	      
  version: 'draft',	      
-  component_resolver: ->(component, data) {	
-    "Placeholder for #{component}: #{data['text']}"	
-  }	
)
``` 

I had to comment the line 19 in _footer.html.slim as `new_user_session_path` is not defined. Other than that the HTML was rendered and delivered. Screenshot below:

![Bildschirmfoto 2020-04-18 um 19 27 10](https://user-images.githubusercontent.com/7952803/79644713-fdc21580-81aa-11ea-8175-e9c6533159a7.jpg)
